### PR TITLE
fix: Update ID conversion

### DIFF
--- a/src/Traits/AuditsTrait.php
+++ b/src/Traits/AuditsTrait.php
@@ -76,13 +76,15 @@ trait AuditsTrait
     // record successful update events
     protected function auditUpdate(array $data)
     {
-        $audit = [
-            'source'    => $this->table,
-            'source_id' => $data['id'],
-            'event'     => 'update',
-            'summary'   => count($data['data']) . ' fields',
-        ];
-        service('audits')->add($audit);
+        foreach ($data['id'] as $sourceId) {
+            $audit = [
+                'source'    => $this->table,
+                'source_id' => $sourceId,
+                'event'     => 'update',
+                'summary'   => count($data['data']) . ' fields',
+            ];
+            service('audits')->add($audit);
+        }
 
         return $data;
     }

--- a/tests/_support/DatabaseTestCase.php
+++ b/tests/_support/DatabaseTestCase.php
@@ -62,6 +62,13 @@ abstract class DatabaseTestCase extends CIUnitTestCase
         $this->fabricator = new Fabricator($this->model);
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->resetServices();
+    }
+
     /**
      * Asserts that an audit with the given properties is in the queue
      *

--- a/tests/unit/LibraryTest.php
+++ b/tests/unit/LibraryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\Models\WidgetModel;
+
+/**
+ * @internal
+ */
+final class LibraryTest extends DatabaseTestCase
+{
+    public function testSaves()
+    {
+        $widget = fake(WidgetModel::class);
+
+        $this->seeInDatabase('widgets', (array) $widget);
+    }
+}

--- a/tests/unit/TraitTest.php
+++ b/tests/unit/TraitTest.php
@@ -40,7 +40,7 @@ final class TraitTest extends DatabaseTestCase
 
         $expected = [
             'source'    => 'widgets',
-            'source_id' => [$widgetId],
+            'source_id' => $widgetId,
             'event'     => 'update',
             'summary'   => '2 fields',
             'user_id'   => 0,
@@ -49,6 +49,30 @@ final class TraitTest extends DatabaseTestCase
         $queue = service('audits')->getQueue();
 
         $this->assertCount(2, $queue);
+        $this->seeAudit($expected);
+    }
+
+    public function testUpdateAddsMultiple()
+    {
+        $widget1 = fake(WidgetModel::class);
+        $widget2 = fake(WidgetModel::class);
+        $ids     = [$widget1->id, $widget2->id]; // @phpstan-ignore-line
+
+        $this->model->update($ids, [
+            'name' => 'Banana Widget',
+        ]);
+
+        $expected = [
+            'source'    => 'widgets',
+            'source_id' => $ids[0],
+            'event'     => 'update',
+            'summary'   => '2 fields',
+            'user_id'   => 0,
+        ];
+
+        $queue = service('audits')->getQueue();
+
+        $this->assertCount(4, $queue);
         $this->seeAudit($expected);
     }
 }


### PR DESCRIPTION
Fixes a bug where the `id` field was incorrectly being coerced instead of handled as an array.